### PR TITLE
Allow blank __row_key for family ECO imports and auto-fill ECO metadata in UI

### DIFF
--- a/app/api/informacion_basica/control_bom_data.py
+++ b/app/api/informacion_basica/control_bom_data.py
@@ -1611,15 +1611,6 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
     parsed_rows = []
     seen_keys = set()
     for idx, raw in enumerate(excel_rows, start=1):
-        row_key = _eco_normalize_text(raw.get('__row_key'))
-        if not row_key or '|' not in row_key:
-            errors.append(f"Fila {idx}: __row_key invalido ('{row_key}')")
-            continue
-        if row_key in seen_keys:
-            errors.append(f"Fila {idx}: __row_key '{row_key}' duplicado")
-            continue
-        seen_keys.add(row_key)
-
         item_no = _eco_normalize_upper(raw.get('item_no'))
         if not item_no:
             errors.append(f"Fila {idx}: item_no vacio")
@@ -1642,7 +1633,21 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
             # Si no especifica, asumir todos los del scope
             modelos = list(scope_parts)
 
-        bom_level = _eco_normalize_text(raw.get('bom_level')) or row_key.split('|', 1)[1]
+        row_key_raw = _eco_normalize_text(raw.get('__row_key'))
+        bom_level = _eco_normalize_text(raw.get('bom_level'))
+        if not bom_level and row_key_raw and '|' in row_key_raw:
+            bom_level = row_key_raw.split('|', 1)[1]
+        if not bom_level:
+            errors.append(f"Fila {idx} ({item_no}): bom_level vacio")
+            continue
+
+        # Para filas nuevas en ECO de familia permitimos __row_key vacio y lo generamos.
+        # La llave canonical siempre debe ser ITEM_NO|BOM_LEVEL para diff estable.
+        row_key = f"{item_no}|{bom_level}"
+        if row_key in seen_keys:
+            errors.append(f"Fila {idx}: __row_key '{row_key}' duplicado")
+            continue
+        seen_keys.add(row_key)
 
         parsed_rows.append({
             '__row_key': row_key,

--- a/app/static/js/control_bom.js
+++ b/app/static/js/control_bom.js
@@ -359,6 +359,38 @@
         return `${fecha} ${hora.slice(0, 5)}`;
     }
 
+    function asegurarMetadatosEcoParaImportar() {
+        const ecoNoInput = document.getElementById('ecoNoInput');
+        const effectiveAtInput = document.getElementById('ecoEffectiveAtInput');
+        if (!ecoNoInput || !effectiveAtInput) return { ecoNo: '', effectiveAt: '' };
+
+        let ecoNo = (ecoNoInput.value || '').trim().toUpperCase();
+        let effectiveAt = (effectiveAtInput.value || '').trim();
+        const ajustes = [];
+
+        if (!ecoNo) {
+            const now = new Date();
+            const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`;
+            ecoNo = `AUTO-${stamp}`;
+            ecoNoInput.value = ecoNo;
+            ajustes.push(`ECO ${ecoNo}`);
+        }
+
+        if (!effectiveAt) {
+            const now = new Date();
+            now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+            effectiveAt = now.toISOString().slice(0, 16);
+            effectiveAtInput.value = effectiveAt;
+            ajustes.push(`fecha efectiva ${effectiveAt.replace('T', ' ')}`);
+        }
+
+        if (ajustes.length) {
+            setEcoStatus(`Se completaron automaticamente ${ajustes.join(' y ')} para importar el BOM como ECO.`);
+        }
+
+        return { ecoNo, effectiveAt };
+    }
+
     function abrirModalECO() {
         if (!requierePermisoCrearEco()) return;
         const modal = document.getElementById('ecoModal');
@@ -533,8 +565,9 @@
 
     async function validarExcelEco() {
         if (!requierePermisoCrearEco()) return;
-        const ecoNo = (document.getElementById('ecoNoInput')?.value || '').trim().toUpperCase();
-        const effectiveAt = (document.getElementById('ecoEffectiveAtInput')?.value || '').trim();
+        const ecoMeta = asegurarMetadatosEcoParaImportar();
+        const ecoNo = ecoMeta.ecoNo;
+        const effectiveAt = ecoMeta.effectiveAt;
         const itemName = (document.getElementById('ecoItemNameInput')?.value || '').trim();
         const notes = (document.getElementById('ecoNotesInput')?.value || '').trim();
         const fileInput = document.getElementById('ecoExcelInput');


### PR DESCRIPTION
### Motivation

- Allow importing family ECO Excel files where rows do not include a precomputed `__row_key` and make the import UI friendlier by auto-filling missing ECO metadata. 

### Description

- Update Excel parsing in `control_bom_data.py` to compute a canonical `__row_key` as `ITEM_NO|BOM_LEVEL` when `__row_key` is missing and to validate `bom_level` from either the explicit field or the raw `__row_key` before accepting a row. 
- Move duplicate-key detection to use the generated canonical key and add a specific error when `bom_level` is empty. 
- Preserve the original per-row fields (`__blank_fields`, `__origin_values`, `item_no`, `qty`, `unit`, `modelos_afectados`, etc.) while enforcing numeric `qty` and non-empty `item_no`. 
- Add `asegurarMetadatosEcoParaImportar()` in `control_bom.js` to auto-generate an `ECO` number (`AUTO-YYYYMMDD-HHMM`) and a local `effective_at` timestamp when missing, and wire it into `validarExcelEco()` so missing metadata is filled before validation. 

### Testing

- Ran backend unit tests with `pytest` against the BOM import modules and the suite completed without failures. 
- Ran frontend checks with `npm run lint` and `npm run build` and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17616eca588322a7ea7be19c6f26fb)