### PR TITLE
Support family-ECO rows without __row_key and auto-fill ECO metadata in UI

### DIFF
--- a/app/api/informacion_basica/control_bom_data.py
+++ b/app/api/informacion_basica/control_bom_data.py
@@ -1611,15 +1611,6 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
     parsed_rows = []
     seen_keys = set()
     for idx, raw in enumerate(excel_rows, start=1):
-        row_key = _eco_normalize_text(raw.get('__row_key'))
-        if not row_key or '|' not in row_key:
-            errors.append(f"Fila {idx}: __row_key invalido ('{row_key}')")
-            continue
-        if row_key in seen_keys:
-            errors.append(f"Fila {idx}: __row_key '{row_key}' duplicado")
-            continue
-        seen_keys.add(row_key)
-
         item_no = _eco_normalize_upper(raw.get('item_no'))
         if not item_no:
             errors.append(f"Fila {idx}: item_no vacio")
@@ -1642,7 +1633,21 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
             # Si no especifica, asumir todos los del scope
             modelos = list(scope_parts)
 
-        bom_level = _eco_normalize_text(raw.get('bom_level')) or row_key.split('|', 1)[1]
+        row_key_raw = _eco_normalize_text(raw.get('__row_key'))
+        bom_level = _eco_normalize_text(raw.get('bom_level'))
+        if not bom_level and row_key_raw and '|' in row_key_raw:
+            bom_level = row_key_raw.split('|', 1)[1]
+        if not bom_level:
+            errors.append(f"Fila {idx} ({item_no}): bom_level vacio")
+            continue
+
+        # Para filas nuevas en ECO de familia permitimos __row_key vacio y lo generamos.
+        # La llave canonical siempre debe ser ITEM_NO|BOM_LEVEL para diff estable.
+        row_key = f"{item_no}|{bom_level}"
+        if row_key in seen_keys:
+            errors.append(f"Fila {idx}: __row_key '{row_key}' duplicado")
+            continue
+        seen_keys.add(row_key)
 
         parsed_rows.append({
             '__row_key': row_key,

--- a/app/static/js/control_bom.js
+++ b/app/static/js/control_bom.js
@@ -359,6 +359,38 @@
         return `${fecha} ${hora.slice(0, 5)}`;
     }
 
+    function asegurarMetadatosEcoParaImportar() {
+        const ecoNoInput = document.getElementById('ecoNoInput');
+        const effectiveAtInput = document.getElementById('ecoEffectiveAtInput');
+        if (!ecoNoInput || !effectiveAtInput) return { ecoNo: '', effectiveAt: '' };
+
+        let ecoNo = (ecoNoInput.value || '').trim().toUpperCase();
+        let effectiveAt = (effectiveAtInput.value || '').trim();
+        const ajustes = [];
+
+        if (!ecoNo) {
+            const now = new Date();
+            const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`;
+            ecoNo = `AUTO-${stamp}`;
+            ecoNoInput.value = ecoNo;
+            ajustes.push(`ECO ${ecoNo}`);
+        }
+
+        if (!effectiveAt) {
+            const now = new Date();
+            now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+            effectiveAt = now.toISOString().slice(0, 16);
+            effectiveAtInput.value = effectiveAt;
+            ajustes.push(`fecha efectiva ${effectiveAt.replace('T', ' ')}`);
+        }
+
+        if (ajustes.length) {
+            setEcoStatus(`Se completaron automaticamente ${ajustes.join(' y ')} para importar el BOM como ECO.`);
+        }
+
+        return { ecoNo, effectiveAt };
+    }
+
     function abrirModalECO() {
         if (!requierePermisoCrearEco()) return;
         const modal = document.getElementById('ecoModal');
@@ -533,8 +565,9 @@
 
     async function validarExcelEco() {
         if (!requierePermisoCrearEco()) return;
-        const ecoNo = (document.getElementById('ecoNoInput')?.value || '').trim().toUpperCase();
-        const effectiveAt = (document.getElementById('ecoEffectiveAtInput')?.value || '').trim();
+        const ecoMeta = asegurarMetadatosEcoParaImportar();
+        const ecoNo = ecoMeta.ecoNo;
+        const effectiveAt = ecoMeta.effectiveAt;
         const itemName = (document.getElementById('ecoItemNameInput')?.value || '').trim();
         const notes = (document.getElementById('ecoNotesInput')?.value || '').trim();
         const fileInput = document.getElementById('ecoExcelInput');


### PR DESCRIPTION
### Motivation
- Allow importing family ECO Excel files where rows may not include a precomputed `__row_key` and ensure stable canonical keys are generated for diffs. 
- Improve UX by auto-populating required ECO metadata (ECO number and effective date) in the client when missing to reduce blocking validation errors.

### Description
- In `crear_eco_familia_desde_excel` changed row parsing to derive `bom_level` from the `bom_level` column or from `__row_key` if present, and to require `bom_level` explicitly before accepting a row. 
- For family ECO rows with no `__row_key` the server now generates a canonical key in the form `ITEM_NO|BOM_LEVEL`, enforces uniqueness, and keeps existing fields like `__blank_fields` and `__origin_values` in the parsed output. 
- Added client-side function `asegurarMetadatosEcoParaImportar()` to auto-fill `ecoNo` (with an `AUTO-YYYYMMDD-HHMM` stamp when missing) and `effectiveAt` (current local datetime) and notify the user via `setEcoStatus`. 
- Updated `validarExcelEco` to use the auto-fill helper so validation no longer blocks when ECO metadata is absent, and minor formatting/utility tweaks in `control_bom.js` (e.g. `escapeHtml` and `formatFechaEfectiva`).

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17616eca588322a7ea7be19c6f26fb)