### PR TITLE
Support blank __row_key for family ECO imports; generate canonical keys and auto-fill ECO metadata in UI

### DIFF
--- a/app/api/informacion_basica/control_bom_data.py
+++ b/app/api/informacion_basica/control_bom_data.py
@@ -1611,15 +1611,6 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
     parsed_rows = []
     seen_keys = set()
     for idx, raw in enumerate(excel_rows, start=1):
-        row_key = _eco_normalize_text(raw.get('__row_key'))
-        if not row_key or '|' not in row_key:
-            errors.append(f"Fila {idx}: __row_key invalido ('{row_key}')")
-            continue
-        if row_key in seen_keys:
-            errors.append(f"Fila {idx}: __row_key '{row_key}' duplicado")
-            continue
-        seen_keys.add(row_key)
-
         item_no = _eco_normalize_upper(raw.get('item_no'))
         if not item_no:
             errors.append(f"Fila {idx}: item_no vacio")
@@ -1642,10 +1633,25 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
             # Si no especifica, asumir todos los del scope
             modelos = list(scope_parts)
 
-        bom_level = _eco_normalize_text(raw.get('bom_level')) or row_key.split('|', 1)[1]
+        row_key_raw = _eco_normalize_text(raw.get('__row_key'))
+        bom_level = _eco_normalize_text(raw.get('bom_level'))
+        if not bom_level and row_key_raw and '|' in row_key_raw:
+            bom_level = row_key_raw.split('|', 1)[1]
+        if not bom_level:
+            errors.append(f"Fila {idx} ({item_no}): bom_level vacio")
+            continue
+
+        # Para filas nuevas en ECO de familia permitimos __row_key vacio y lo generamos.
+        # La llave canonical siempre debe ser ITEM_NO|BOM_LEVEL para diff estable.
+        row_key = f"{item_no}|{bom_level}"
+        if row_key in seen_keys:
+            errors.append(f"Fila {idx}: __row_key '{row_key}' duplicado")
+            continue
+        seen_keys.add(row_key)
 
         parsed_rows.append({
             '__row_key': row_key,
+            '__row_key_raw': row_key_raw,
             '__blank_fields': _eco_family_raw_blank_fields(raw),
             '__origin_values': _eco_family_origin_values(raw),
             'item_no': item_no,
@@ -1687,6 +1693,7 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
 
     for row in parsed_rows:
         key = row['__row_key']
+        is_new_row_intent = not _eco_normalize_text(row.get('__row_key_raw'))
         for pn in row['modelos_afectados']:
             current = bom_by_part_key.get(pn, {}).get(key)
             if current is None:
@@ -1697,6 +1704,12 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
                     'row': row,
                 })
             else:
+                if is_new_row_intent:
+                    errors.append(
+                        f"Fila nueva '{row['item_no']}' en modelo {pn} ya existe con bom_level {row['bom_level']}. "
+                        "Para añadir, use un bom_level nuevo; para modificar, conserve __row_key original."
+                    )
+                    continue
                 field_diffs = []
                 blank_fields = row.get('__blank_fields') or set()
                 for field in _ECO_DIFF_CRITICAL_FIELDS:
@@ -1734,6 +1747,9 @@ def crear_eco_familia_desde_excel(metadata, excel_rows, scope_parts, created_by=
                     'item_no': original.get('item_no'),
                     'bom_level': original.get('bom_level'),
                 })
+
+    if errors:
+        return {"success": False, "errors": errors}
 
     if not (diff_added or diff_removed or diff_modified):
         return {"success": False, "errors": ["El Excel no contiene cambios respecto al BOM actual"]}

--- a/app/static/js/control_bom.js
+++ b/app/static/js/control_bom.js
@@ -359,6 +359,38 @@
         return `${fecha} ${hora.slice(0, 5)}`;
     }
 
+    function asegurarMetadatosEcoParaImportar() {
+        const ecoNoInput = document.getElementById('ecoNoInput');
+        const effectiveAtInput = document.getElementById('ecoEffectiveAtInput');
+        if (!ecoNoInput || !effectiveAtInput) return { ecoNo: '', effectiveAt: '' };
+
+        let ecoNo = (ecoNoInput.value || '').trim().toUpperCase();
+        let effectiveAt = (effectiveAtInput.value || '').trim();
+        const ajustes = [];
+
+        if (!ecoNo) {
+            const now = new Date();
+            const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`;
+            ecoNo = `AUTO-${stamp}`;
+            ecoNoInput.value = ecoNo;
+            ajustes.push(`ECO ${ecoNo}`);
+        }
+
+        if (!effectiveAt) {
+            const now = new Date();
+            now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+            effectiveAt = now.toISOString().slice(0, 16);
+            effectiveAtInput.value = effectiveAt;
+            ajustes.push(`fecha efectiva ${effectiveAt.replace('T', ' ')}`);
+        }
+
+        if (ajustes.length) {
+            setEcoStatus(`Se completaron automaticamente ${ajustes.join(' y ')} para importar el BOM como ECO.`);
+        }
+
+        return { ecoNo, effectiveAt };
+    }
+
     function abrirModalECO() {
         if (!requierePermisoCrearEco()) return;
         const modal = document.getElementById('ecoModal');
@@ -533,8 +565,9 @@
 
     async function validarExcelEco() {
         if (!requierePermisoCrearEco()) return;
-        const ecoNo = (document.getElementById('ecoNoInput')?.value || '').trim().toUpperCase();
-        const effectiveAt = (document.getElementById('ecoEffectiveAtInput')?.value || '').trim();
+        const ecoMeta = asegurarMetadatosEcoParaImportar();
+        const ecoNo = ecoMeta.ecoNo;
+        const effectiveAt = ecoMeta.effectiveAt;
         const itemName = (document.getElementById('ecoItemNameInput')?.value || '').trim();
         const notes = (document.getElementById('ecoNotesInput')?.value || '').trim();
         const fileInput = document.getElementById('ecoExcelInput');


### PR DESCRIPTION
### Motivation

- Make importing family ECOs from Excel more forgiving by allowing rows without `__row_key` and by auto-generating a stable canonical key, and reduce accidental modifies vs adds when users add new rows. 
- Improve UX by auto-filling missing ECO metadata (ECO number and effective date) in the import UI to streamline the import flow.

### Description

- Updated `crear_eco_familia_desde_excel` to accept rows without `__row_key`, infer or require `bom_level`, and generate a canonical `__row_key` of `ITEM_NO|BOM_LEVEL` when appropriate while storing the original value in `__row_key_raw`.
- Added duplicate detection and explicit error reporting for cases where a user intends to add a new row but an item with the same canonical key already exists, and introduced a validation error when `bom_level` cannot be determined.
- Kept the diff logic but added `is_new_row_intent` detection to prevent silently turning an intended ADD into a MODIFY, and preserved existing checks for `diff_added`, `diff_removed`, and `diff_modified`.
- Frontend: added `asegurarMetadatosEcoParaImportar()` and updated `validarExcelEco()` to auto-complete and persist missing `eco_no` and `effective_at` values (generating an `AUTO-<timestamp>` ECO and timezone-correct ISO datetime), and notify the user via status text.

### Testing

- Ran the backend unit test suite via `pytest` and all tests passed.
- Ran the frontend build/lint check (`npm run lint`) and no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17616eca588322a7ea7be19c6f26fb)